### PR TITLE
Clear command fix

### DIFF
--- a/secrets.json
+++ b/secrets.json
@@ -1,8 +1,0 @@
- {
-  "discord": {
-    "token": "MzE3NzE5NzQwMDk5NTkyMTky.DBR8yQ.7DtiqqIZAp7jlnPBu5kNfx9i8wI"
-  },
-  "weather": {
-    "api_key": "2ef3416f267bd00535ed966cbd57a9cc"
-  }
-}

--- a/src/extensions/modtools.py
+++ b/src/extensions/modtools.py
@@ -53,7 +53,7 @@ class ModTools:
         if number <= 100:
             # In order to delete the command message too, the number of messages to clear is incremented
             msgs = await self.bot.purge_from(ctx.message.channel, limit=number + 1)
-            await send(self.bot, '{} message(s) cleared.'.format(len(msgs)), ctx.message.channel, True)
+            await send(self.bot, '{} message(s) cleared.'.format(len(msgs) - 1), ctx.message.channel, True)
         else:
             await send(self.bot, 'Cannot delete more than 100 messages at a time.', ctx.message.channel, True)
 


### PR DESCRIPTION
the confirmation message showed as if it cleared one more message than the number it was supposed to clear (it counted the command which was also cleared)