### PR TITLE
Clear command fix

### DIFF
--- a/src/extensions/modtools.py
+++ b/src/extensions/modtools.py
@@ -53,6 +53,8 @@ class ModTools:
         if number <= 100:
             # In order to delete the command message too, the number of messages to clear is incremented
             msgs = await self.bot.purge_from(ctx.message.channel, limit=number + 1)
+            # msgs also contains the clear command message itself, so the actual number of cleared messages is the
+            # number of messages cleared minus one
             await send(self.bot, '{} message(s) cleared.'.format(len(msgs) - 1), ctx.message.channel, True)
         else:
             await send(self.bot, 'Cannot delete more than 100 messages at a time.', ctx.message.channel, True)

--- a/src/extensions/modtools.py
+++ b/src/extensions/modtools.py
@@ -53,7 +53,7 @@ class ModTools:
         if number <= 100:
             # In order to delete the command message too, the number of messages to clear is incremented
             msgs = await self.bot.purge_from(ctx.message.channel, limit=number + 1)
-            await send(self.bot, '{} message(s) cleared.'.format(len(msgs)), ctx.message.channel, True)
+            await send(self.bot, '{} message(s) cleared.'.format(len(msgs) + 1), ctx.message.channel, True)
         else:
             await send(self.bot, 'Cannot delete more than 100 messages at a time.', ctx.message.channel, True)
 

--- a/src/extensions/modtools.py
+++ b/src/extensions/modtools.py
@@ -53,7 +53,7 @@ class ModTools:
         if number <= 100:
             # In order to delete the command message too, the number of messages to clear is incremented
             msgs = await self.bot.purge_from(ctx.message.channel, limit=number + 1)
-            await send(self.bot, '{} message(s) cleared.'.format(len(msgs) + 1), ctx.message.channel, True)
+            await send(self.bot, '{} message(s) cleared.'.format(len(msgs) - 1), ctx.message.channel, True)
         else:
             await send(self.bot, 'Cannot delete more than 100 messages at a time.', ctx.message.channel, True)
 


### PR DESCRIPTION
The confirmation message after a successful clear showed the number of messages cleared, but it was 1 above the wanted number.
(it counted the clear command itself, which is deleted when the command is running)