### PR TITLE
Fix ?stats online bug showing only online users and make fields in user top list non-inline

### DIFF
--- a/src/extensions/statistics.py
+++ b/src/extensions/statistics.py
@@ -109,7 +109,7 @@ class Statistics:
         embed = discord.Embed(color=discord.Color(self.config.embed_color), timestamp=datetime.datetime.now())
         embed.set_footer(text='Global footer for all embeds', icon_url='https://cdn.discordapp.com/embed/avatars/2.png')
         for user in users:
-            embed.add_field(name=user.name, value='Total messages: {}'.format(user.total_messages))
+            embed.add_field(name=user.name, value='Total messages: {}'.format(user.total_messages), inline=False)
         await self.bot.say(content='Top active users:', embed=embed)
 
 

--- a/src/extensions/statistics.py
+++ b/src/extensions/statistics.py
@@ -60,7 +60,7 @@ class Statistics:
         :param ctx: the context
         """
         server = ctx.message.server
-        online = [1 if m.status == discord.Status.online else 0 for m in server.members]
+        online = [1 if m.status != discord.Status.offline else 0 for m in server.members]
         await self.bot.say('{} users online'.format(sum(online)))
 
     @stats.group(pass_context=True)


### PR DESCRIPTION
`?stats online` should now only exclude offline users. It should now report idle and dnd as online.

User top list should now display correctly with non-inline fields