### PR TITLE
Fix bugs in ?stats messages users

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -92,6 +92,7 @@ class Message(DiscordModel):
     body = TextField()
     edited = DateTimeField(null=True)
     is_command = BooleanField(default=False)
+    is_embed = BooleanField(default=False)
 
 
 class ServerNick(BaseModel):


### PR DESCRIPTION
- A user without a name will not crash the command, discord_id is used
instead

- count now defaults to 10