### PR TITLE
Permissions and disallow whois in private channels

### DIFF
--- a/src/extensions/aryas_orm.py
+++ b/src/extensions/aryas_orm.py
@@ -53,7 +53,7 @@ class Query:
                         self.models.User.is_bot == False,
                         self.models.Server.id == server)
                  .annotate(self.models.Message)  # annotate alias to 'count'
-                 .order_by(SQL('count'))
+                 .order_by(SQL('count').desc())
                  .limit(count))
         return users
 

--- a/src/extensions/fun.py
+++ b/src/extensions/fun.py
@@ -8,6 +8,7 @@ from discord.ext import commands
 from urllib.parse import quote_plus
 from typing import List, Tuple
 from src.extensions.config import Config
+from src.utility import in_channel
 
 
 class Fun:
@@ -16,6 +17,7 @@ class Fun:
         self.config: Config = self.bot.cogs['Config']
 
     @commands.command()
+    @commands.has_any_role('Support', 'Moderator', 'Admin')
     async def lmgtfy(self, *, search) -> None:
         """
         For when Googling is enough
@@ -25,6 +27,7 @@ class Fun:
         await self.bot.say(url)
 
     @commands.command(pass_context=True)
+    @in_channel('bot_info_channel')
     async def roll(self, ctx: commands.Context) -> None:
         """
         Rolls a dice and outputs a message depending on the result
@@ -38,6 +41,7 @@ class Fun:
                 '{} The gods are with you, you rolled **{}**'.format(ctx.message.author.mention, random_dice))
 
     @commands.command(pass_context=True)
+    @in_channel('bot_info_channel')
     async def telljoke(self, ctx: commands.Context) -> None:
         """
         Responds with a random joke from theoatmeal.com
@@ -60,6 +64,7 @@ class Fun:
         await self.bot.say(joke)
 
     @commands.command(pass_context=True)
+    @in_channel('bot_info_channel')
     async def randomfact(self, ctx: commands.Context) -> None:
         """
         Responds with a random fact scraped from unkno.com

--- a/src/extensions/general.py
+++ b/src/extensions/general.py
@@ -2,7 +2,7 @@ import discord
 import pyowm
 from discord.ext import commands
 from discord.ext.commands import bot as bot_module
-from src.utility import send, command_error, update_user_fields
+from src.utility import send, command_error, update_user_fields, in_channel
 from urllib import request
 import json
 import time
@@ -84,6 +84,7 @@ class General:
             await bot.send_message(destination, embed=embed)
 
     @commands.command(pass_context=True)
+    @in_channel('bot_info_channel')
     async def whois(self, ctx: commands.Context, member: discord.Member) -> None:
         """
         Returns information about the given member
@@ -149,6 +150,7 @@ class General:
             self.config.logger.error('Cannot look up member in PrivateChannel')
 
     @commands.command(pass_context=True)
+    @in_channel('bot_info_channel')
     async def ping(self, ctx: commands.Context) -> None:
         """
                 Responds with the latency time.
@@ -220,6 +222,7 @@ class General:
              .format(msg.author.mention, love, member.mention), ctx.message.channel)
 
     @commands.command(pass_context=True)
+    @in_channel('bot_info_channel')
     async def convert_currency(self, ctx: commands.Context, amount: float, base, to) -> None:
         """
         Calculates the requested currency conversion
@@ -241,6 +244,7 @@ class General:
             send(self.bot, 'Could not convert {} {} to {}'.format(amount, base, to), ctx.message.channel, True)
 
     @commands.command(pass_context=True)
+    @in_channel('bot_info_channel')
     async def convert_length(self, ctx: commands.Context, amount: float, unit1, unit2) -> None:
         """
         Calculates the requested length conversion
@@ -259,6 +263,7 @@ class General:
                  ctx.message.channel, True)
 
     @commands.command(pass_context=True)
+    @in_channel('bot_info_channel')
     async def convert_mass(self, ctx: commands.Context, amount: float, unit1, unit2) -> None:
         """
         Calculates the requested mass conversion
@@ -277,6 +282,7 @@ class General:
                  ctx.message.channel, True)
 
     @commands.command(pass_context=True)
+    @in_channel('bot_info_channel')
     async def weather(self, ctx: commands.Context, city, country) -> None:
         """
         Gives info regarding the weather in a city
@@ -299,6 +305,7 @@ class General:
                  .format(country, city), ctx.message.channel, True)
 
     @commands.command(pass_context=True)
+    @commands.has_any_role('Support', 'Moderator', 'Admin')
     async def search(self, ctx:commands.Context) -> None:
         """
         Searches google, returns the title of the first 5 results along with their descriptions.

--- a/src/extensions/statistics.py
+++ b/src/extensions/statistics.py
@@ -21,7 +21,7 @@ class Statistics:
         increments the users total messages.
         :param msg: the message
         """
-        if not isinstance(msg.channel, PrivateChannel):
+        if not msg.channel.is_private:
             try:
                 # append embeds list to message
                 body = msg.content
@@ -54,7 +54,7 @@ class Statistics:
                 self.config.logger.error(e)
 
     @commands.group(pass_context=True)
-    @commands.has_role('Admin')
+    @commands.has_any_role('Admin', 'Moderator', 'Support')
     async def stats(self, ctx: commands.Context):
         """
         Group of statistics commands
@@ -64,7 +64,6 @@ class Statistics:
             await self.bot.say('`Usage: ?stats <subcommand>`')
 
     @stats.command(pass_context=True)
-    @commands.has_role('Admin')
     async def online(self, ctx: commands.Context):
         """
         Show total online users on sever
@@ -75,7 +74,6 @@ class Statistics:
         await self.bot.say('{} users online'.format(sum(online)))
 
     @stats.group(pass_context=True)
-    @commands.has_role('Admin')
     async def messages(self, ctx: commands.Context):
         """
         Group of message related commands
@@ -85,7 +83,6 @@ class Statistics:
             await self.bot.say('`Usage: ?stats messages <subcommand>`')
 
     @messages.command(pass_context=True)
-    @commands.has_role('Admin')
     async def total(self, ctx: commands.Context):
         """
         Show total amount of messages on server
@@ -96,7 +93,6 @@ class Statistics:
         await self.bot.say('Total messages: {}'.format(total_messages))
 
     @messages.command(pass_context=True)
-    @commands.has_role('Admin')
     async def users(self, ctx: commands.Context, count=10):
         """
         Show users with the most messages

--- a/src/utility.py
+++ b/src/utility.py
@@ -23,6 +23,18 @@ def is_command(bot, cmd):
     return cmd in bot.commands
 
 
+def in_channel(name):
+    """
+    Checks if command is sent in a given channel
+    :param name: name of the channel
+    :return:
+    """
+    def predicate(ctx):
+        return ctx.message.channel.name == name
+
+    return commands.check(predicate)
+
+
 def update_user_fields(user, member: Member):
     """
     Updates a users fields in the database with latest data from discord


### PR DESCRIPTION
- Adds a decorator `in_channel(name)` to check if a message was sent in a particular channel
- Changed permissions on the commands to match issue.txt
- Disallow ?whois in private messages
- Fix order in user top list to descending