### PR TITLE
Remove everything but text from docstrings

### DIFF
--- a/aryas/extensions/fun.py
+++ b/aryas/extensions/fun.py
@@ -33,7 +33,6 @@ class Fun:
     async def roll(self, ctx: commands.Context) -> None:
         """
         Rolls a dice and outputs a message depending on the result
-        :param ctx: The message context
         """
         random_dice = randint(1, 6)
         if random_dice < 4:
@@ -47,7 +46,6 @@ class Fun:
     async def telljoke(self, ctx: commands.Context) -> None:
         """
         Responds with a random joke from theoatmeal.com
-        :param ctx: The message context
         """
         # TODO: get more joke formats (or a better source)
         # Send typing as the request can take some time.
@@ -70,7 +68,6 @@ class Fun:
     async def randomfact(self, ctx: commands.Context) -> None:
         """
         Responds with a random fact scraped from unkno.com
-        :param ctx: The message context
         """
         # Send typing as the request can take some time.
         await self.bot.send_typing(ctx.message.channel)
@@ -86,13 +83,12 @@ class Fun:
         await self.bot.say(soup.find(id='content').text)
 
     @commands.command(pass_context=True)
-    @commands.has_role('Moderator')
+    @commands.has_any_role('Admin', 'Moderator', 'Support')
     async def poll(self, ctx: commands.Context) -> None:
         """
         Creates an interactive poll for the moderators
             The format to ask a question is :
                                '?survey <question here> ? <survey 1> - <survey 2> - ... ! <nb of minutes for timeout>')
-        :param ctx:     The context of the message (cf discord doc)
         """
 
         usage = "?poll <question>; <length in seconds>; <option 1>; <option 2>; ..."

--- a/aryas/extensions/general.py
+++ b/aryas/extensions/general.py
@@ -87,8 +87,6 @@ class General:
     async def whois(self, ctx: commands.Context, member: discord.Member) -> None:
         """
         Returns information about the given member
-        :param ctx: the message context
-        :param member: target member
         """
         if not ctx.message.channel.is_private:
             user = self.orm.User.get_or_create(discord_id=member.id)[0]
@@ -152,9 +150,9 @@ class General:
     @in_channel('bot_info_channel')
     async def ping(self, ctx: commands.Context) -> None:
         """
-                Responds with the latency time.
-                Time took for Aryas to reply
-                """
+        Responds with the latency time.
+        Time took for Aryas to reply
+        """
         before = time.monotonic()
         await self.bot.send_typing(ctx.message.author)
         after = time.monotonic()
@@ -165,8 +163,6 @@ class General:
     async def get_love(self, ctx: commands.Context, member: discord.Member = None) -> None:
         """
         Gives info regarding the amount of love a user has
-        :param ctx: the message context
-        :param member: the member
         """
         if member is None:
             member = ctx.message.author
@@ -181,9 +177,6 @@ class General:
     async def show_love(self, ctx: commands.Context, member: discord.Member, love: int) -> None:
         """
         Gives love to a user
-        :param ctx: the message context
-        :param member: the member to give the love to
-        :param love: the amount of love to give
         """
 
         if member == ctx.message.author:
@@ -225,10 +218,6 @@ class General:
     async def convert_currency(self, ctx: commands.Context, amount: float, base, to) -> None:
         """
         Calculates the requested currency conversion
-        :param ctx: the message context
-        :param amount: the amount to convert
-        :param base: the base unit (e.g. USD, EUR)
-        :param to: the conversion unit (e.g. ILS, GBP)
         """
         await self.bot.send_typing(ctx.message.channel)
         base = base.upper()
@@ -247,10 +236,6 @@ class General:
     async def convert_length(self, ctx: commands.Context, amount: float, unit1, unit2) -> None:
         """
         Calculates the requested length conversion
-        :param ctx: the message context
-        :param amount: the amount to convert
-        :param unit1: the original unit
-        :param unit2: the unit to convert to
         """
         len_units = self.config.constants.len_units
         try:
@@ -266,10 +251,6 @@ class General:
     async def convert_mass(self, ctx: commands.Context, amount: float, unit1, unit2) -> None:
         """
         Calculates the requested mass conversion
-        :param ctx: the message context
-        :param amount: the amount to convert
-        :param unit1: the original unit
-        :param unit2: the unit to convert to
         """
         mass_units = self.config.constants.mass_units
         try:
@@ -285,9 +266,6 @@ class General:
     async def weather(self, ctx: commands.Context, city, country) -> None:
         """
         Gives info regarding the weather in a city
-        :param ctx: the message context
-        :param city: the city
-        :param country: the country
         """
 
         owm = pyowm.OWM(self.config['weather']['api_key'])
@@ -309,7 +287,6 @@ class General:
         """
         Searches google, returns the title of the first 5 results along with their descriptions.
         Allows users to select a result then returns a link.
-        :param ctx:     The message content.
         """
 
         # Creates a service for the CSE, passes the

--- a/aryas/extensions/statistics.py
+++ b/aryas/extensions/statistics.py
@@ -58,7 +58,6 @@ class Statistics:
     async def stats(self, ctx: commands.Context):
         """
         Group of statistics commands
-        :param ctx: the context
         """
         if ctx.invoked_subcommand is None:
             await self.bot.say('`Usage: ?stats <subcommand>`')
@@ -67,7 +66,6 @@ class Statistics:
     async def online(self, ctx: commands.Context):
         """
         Show total online users on sever
-        :param ctx: the context
         """
         server = ctx.message.server
         online = [1 if m.status != discord.Status.offline else 0 for m in server.members]
@@ -77,7 +75,6 @@ class Statistics:
     async def messages(self, ctx: commands.Context):
         """
         Group of message related commands
-        :param ctx: the context
         """
         if ctx.invoked_subcommand is None:
             await self.bot.say('`Usage: ?stats messages <subcommand>`')
@@ -86,7 +83,6 @@ class Statistics:
     async def total(self, ctx: commands.Context):
         """
         Show total amount of messages on server
-        :param ctx: command context
         """
         try:
             server = self.orm.Server.get(discord_id=ctx.message.server.id)
@@ -101,8 +97,6 @@ class Statistics:
     async def users(self, ctx: commands.Context, count=10):
         """
         Show users with the most messages
-        :param ctx: command context
-        :param count: number of users, min 1, max 20
         """
         count = count
         # Show at least 1 user and 20 at most


### PR DESCRIPTION
The help command uses docstrings to construct the help message for the command. It looks nicer if there's not a bunch of `:param:` in there. An alternative approach would be to set the `help` keyword argument in the command decorator.